### PR TITLE
Add ical for events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,9 @@ gem "puma", "< 7"
 
 # Or for faster parsing of HTML-only resources via Inspectors, use Nokolexbor:
 # gem "nokolexbor", "~> 0.4"
+
+# Internet calendaring, Ruby style
+gem "icalendar", "~> 2.10"
+
+# Ruby Time Zone Library
+gem "tzinfo", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       activesupport (>= 5.0.0, < 8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    icalendar (2.10.2)
+      ice_cube (~> 0.16)
+    ice_cube (0.17.0)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -130,7 +133,9 @@ PLATFORMS
 
 DEPENDENCIES
   bridgetown (~> 1.3.4)
+  icalendar (~> 2.10)
   puma (< 7)
+  tzinfo (~> 2.0)
 
 BUNDLED WITH
    2.5.4

--- a/bridgetown.config.yml
+++ b/bridgetown.config.yml
@@ -17,7 +17,7 @@
 # https://learnxinyminutes.com/docs/yaml/
 #
 
-url: "" # the base hostname & protocol for your site, e.g. https://example.com
+url: "https://rubydf.com" # the base hostname & protocol for your site, e.g. https://example.com
 
 permalink: pretty
 template_engine: liquid

--- a/src/_components/calendar.rb
+++ b/src/_components/calendar.rb
@@ -1,0 +1,80 @@
+require "tzinfo"
+require "icalendar"
+require "icalendar/tzinfo"
+
+class Calendar < Bridgetown::Component
+  def initialize(events:, timezone:)
+    @events = events
+    @timezone = timezone
+  end
+
+  def publish
+    calendar = Icalendar::Calendar.new
+
+    calendar.timezone do |timezone|
+      timezone.tzid = timezone_identifier
+    end
+
+    @events.each do |event|
+      title = event.data.title
+      datetime = event.data.date
+      city = event.data.dig(:location, :city)
+      address = event.data.dig(:location, :address)
+      link = event.data.dig(:location, :link)
+      url = event.absolute_url
+      agenda = event.data.talks.map { |talk| "- #{talk.title} (#{talk.speaker.name})" }.join("\n\n")
+      sponsors = event.data.sponsors.map(&:name).to_sentence(two_words_connector: ' e ', last_word_connector: ' e ')
+
+      description = <<~DESCRIPTION
+        RubyDF - #{title}
+
+        Localização:
+        #{address}
+        #{link}
+
+        Agenda:
+        #{agenda}
+
+        Patrocinadores:
+        #{sponsors}
+      DESCRIPTION
+
+      calendar.event do |e|
+        e.dtstart     = ical_time(datetime)
+        e.dtend       = ical_time(datetime + 2.hours)
+        e.summary     = "RubyDF - #{title}"
+        e.location    = city
+        e.url         = url
+        e.description = description
+      end
+    end
+
+    calendar.publish
+  end
+
+  def to_ical
+    publish.to_ical
+  end
+
+  def render_in(_view_context, &block)
+    to_ical
+  end
+
+  private
+
+  def timezone_identifier
+    @timezone
+  end
+
+  def timezone
+    @timezone ||= TZInfo::Timezone.get(timezone_identifier)
+  end
+
+  def ical_timezone
+    timezone.ical_timezone(timezone.now)
+  end
+
+  def ical_time(datetime)
+    Icalendar::Values::DateTime.new(datetime, tzid: timezone_identifier)
+  end
+end

--- a/src/_events/2023-10-07-piloto.md
+++ b/src/_events/2023-10-07-piloto.md
@@ -20,6 +20,7 @@ sponsors:
     link: https://www.lappis.rocks/
 attendees: 19
 location:
+  city: Brasilia, Brazil
   address: Universidade de Brasília - Faculdade do Gama
 categories: event
 ---

--- a/src/_events/2024-02-02-segunda-edicao.md
+++ b/src/_events/2024-02-02-segunda-edicao.md
@@ -28,6 +28,7 @@ sponsors:
     logo: /images/sponsors/switchdreams.png
     link: https://switchdreams.com.br/
 location:
+  city: Brasilia, Brazil
   address: Universidade de Brasília - Faculdade de Tecnologia
 attendees: 25
 categories: event

--- a/src/_events/2024-07-27-terceira-edicao.md
+++ b/src/_events/2024-07-27-terceira-edicao.md
@@ -34,6 +34,7 @@ sponsors:
     link: https://www.ludoteca.com.br
 attendees: 20
 location:
+  city: Brasilia, Brazil
   address: Blocks Coworking & Offices, Águas Claras
   link: https://maps.app.goo.gl/RQriLKQocUB3BkYg8
 categories: event

--- a/src/events.ics
+++ b/src/events.ics
@@ -1,0 +1,9 @@
+---
+layout: null
+template_engine: erb
+---
+
+<%= render Calendar.new(
+  events: collections.events.resources.sort_by(&:date),
+  timezone: site.config.timezone
+) %>


### PR DESCRIPTION
This pull request implements a `ics` calendar for all events. The following calendar gets published:

| URL | Description |
| ---- | ------------ |
| `https://rubydf.com/events.ics`  | All Events |

The main motivation for this is to automate the import of meetups into https://rubyconferences.org/meetups.

This pull request over in RubyConferences.org enables this: https://github.com/ruby-conferences/ruby-conferences.github.io/pull/735.

Let me know if you want me to tweak something. 

Also, leaving this here for context: https://elk.zone/mastodon.social/@matheusrich/113057565633177723
